### PR TITLE
fix: add prefix check to prevent unwanted error message

### DIFF
--- a/source/primary.ts
+++ b/source/primary.ts
@@ -65,6 +65,7 @@ export class ClusterMemoryStorePrimary {
 					requestId,
 					result,
 					from,
+					prefix,
 				}
 				debug('Sending response to worker %d: %o', worker.id, message)
 				worker.send(message)

--- a/source/shared.ts
+++ b/source/shared.ts
@@ -6,13 +6,13 @@ export type Command = keyof Omit<Store, 'prefix' | 'localKeys'>
 
 type Message = {
 	from: 'cluster-memory-store'
+	prefix: string
 }
 
 export type WorkerToPrimaryMessage = Message & {
 	command: Command
 	args: any[]
 	requestId: number
-	prefix: string
 }
 
 export type PrimaryToWorkerMessage = Message & {

--- a/source/worker.ts
+++ b/source/worker.ts
@@ -190,7 +190,7 @@ export class ClusterMemoryStoreWorker implements Store {
 
 	private onMessage(message: any) {
 		debug('Recieved message %o', message)
-		if (message?.from === from) {
+		if (message?.from === from && message?.prefix === this.prefix) {
 			const message_ = message as PrimaryToWorkerMessage
 			if (this.openRequests.has(message_.requestId)) {
 				const { timeoutId, resolve } = this.openRequests.get(


### PR DESCRIPTION
added prefix check on onMessage handler of `ClusterMemoryStoreWorker` to prevent `Error: ClusterMemoryStoreWorker:1: response recieved without matching open request` when using multiple instences of `ClusterMemoryStoreWorker`

Closes #3 